### PR TITLE
Fix for nav menus in "watch" mode

### DIFF
--- a/MenuGenerator.php
+++ b/MenuGenerator.php
@@ -50,7 +50,7 @@ class MenuGenerator implements EventSubscriberInterface
         $sourceSet = $sourceSetEvent->sourceSet();
         $pages = [];
 
-        foreach ($sourceSet->updatedSources() as $source) {
+        foreach ($sourceSet->allSources() as $source) {
             /** @var \Sculpin\Core\Source\FileSource $source */
 
             if ($source->isGenerated() || !$source->canBeFormatted()) {


### PR DESCRIPTION
In sculpin's watch mode (`vendor/bin/sculpin generate --watch --server`), the navigation menu seems to get blanked out on pages that are being edited. From debugging the process in flight, it seems that this is because the `->updatedSources()` method will only return the 1 file being changed, and this doesn't result in a valid menu being assembled.

By switching to `->allSources()`, the bug is fixed, albeit at the performance cost of reapplying the menu for each format run.