### PR TITLE
Update menu array on an item-by-item basis

### DIFF
--- a/MenuGenerator.php
+++ b/MenuGenerator.php
@@ -92,7 +92,19 @@ class MenuGenerator implements EventSubscriberInterface
             ];
         }
 
-        $this->menu = $this->buildMenu($pages);
+        $menu = $this->buildMenu($pages);
+        foreach ($menu as $item) {
+            $key = array_search($item, $this->menu);
+
+            // if we have a hit, replace the matching menu item instead of appending
+            if (false !== $key) {
+                $this->menu[$key] = $item;
+                continue;
+            }
+
+            // fall back to appending unmatched items
+            $this->menu[] = $item;
+        }
 
         $this->setMenu($sourceSet);
     }


### PR DESCRIPTION
There is sometimes an issue when using this bundle where the resulting menu gets erased when a file is edited. It occurs only in `generate --watch` mode, but can make it frustrating to work with sites locally.

This change aims to non-destructively update the menu. Because the event being listened to is not sending the complete data to rebuild the menu from scratch, this means trying to manually identify the matching array value (using `array_search`) and overwriting it directly.

Other approaches might include:

* Index the menu array by a generated key so that guesswork isn't needed to replace it
* Find a way to attach the full dataset to the event being listened to